### PR TITLE
DeepEquals.compareUnorderedCollection方法无法diff出列表的更新

### DIFF
--- a/src/main/java/com/github/meixuesong/aggregatepersistence/deepequals/DeepEquals.java
+++ b/src/main/java/com/github/meixuesong/aggregatepersistence/deepequals/DeepEquals.java
@@ -273,7 +273,8 @@ public class DeepEquals {
         Map<Integer, Collection> map = collection2Map(collectionB);
 
         for (Object item : collectionA) {
-            Collection other = map.get(ReflectionUtils.deepHashCode(item));
+            int hashCode = ReflectionUtils.deepHashCode(item);
+            Collection other = map.get(hashCode);
             // fail fast: item not even found in other Collection, no need to continue.
             if (other == null || other.isEmpty()) {
                 return false;
@@ -282,6 +283,7 @@ public class DeepEquals {
             // no hash collision, items must be equivalent or isDeepEquals is false
             if (other.size() == 1) {
                 recursiveObject.push(new DualObject(item, other.iterator().next()));
+                map.remove(hashCode);
             } else {
                 // hash collision: try all collided items against the current item (if 1 equals, we are good - remove it
                 // from collision list, making further comparisons faster)

--- a/src/test/java/com/github/meixuesong/aggregatepersistence/deepequals/DeepEqualsTest.java
+++ b/src/test/java/com/github/meixuesong/aggregatepersistence/deepequals/DeepEqualsTest.java
@@ -402,6 +402,14 @@ public class DeepEqualsTest {
     }
 
     @Test
+    public void testCollectionNotEquals() {
+        Object[] a1 = new Object[]{"alpha", "alpha", "alpha", "alpha"};
+        Object[] a2 = new Object[]{"alpha", "bravo", "charlie", "delta"};
+
+        assertFalse(deepEquals.isDeepEquals(a1, a2));
+    }
+
+    @Test
     public void testHasCustomMethod() {
         assertFalse(ReflectionUtils.hasCustomEquals(EmptyClass.class));
         assertFalse(ReflectionUtils.hasCustomHashCode(Class1.class));


### PR DESCRIPTION
当compareUnorderedCollection方法的collectionA为[A, A]，collectionB为[A, B]时，compareUnorderedCollection无法正确的识别到diff。